### PR TITLE
Object caching

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -15005,9 +15005,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
      * Remove cacheCanvas and its dimensions from the objects
      */
     _removeCacheCanvas: function() {
-      if (this._cacheContext) {
-        this._cacheContext.dispose();
-      }
       this._cacheCanvas = null;
       this.cacheWidth = 0;
       this.cacheHeight = 0;

--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -14427,7 +14427,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
      * @type Boolean
      * @default true
      */
-    objectCaching:            objectCaching,
+    objectCaching:            false,
 
     /**
      * When `true`, object properties are checked for cache invalidation. In some particular
@@ -15005,6 +15005,9 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
      * Remove cacheCanvas and its dimensions from the objects
      */
     _removeCacheCanvas: function() {
+      if (this._cacheContext) {
+        this._cacheContext.dispose();
+      }
       this._cacheCanvas = null;
       this.cacheWidth = 0;
       this.cacheHeight = 0;

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -515,7 +515,7 @@
      * @type Boolean
      * @default true
      */
-    objectCaching:            objectCaching,
+    objectCaching:            false,
 
     /**
      * When `true`, object properties are checked for cache invalidation. In some particular
@@ -1093,6 +1093,9 @@
      * Remove cacheCanvas and its dimensions from the objects
      */
     _removeCacheCanvas: function() {
+      if (this._cacheContext) {
+        this._cacheContext.dispose();
+      }
       this._cacheCanvas = null;
       this.cacheWidth = 0;
       this.cacheHeight = 0;

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1093,9 +1093,6 @@
      * Remove cacheCanvas and its dimensions from the objects
      */
     _removeCacheCanvas: function() {
-      if (this._cacheContext) {
-        this._cacheContext.dispose();
-      }
       this._cacheCanvas = null;
       this.cacheWidth = 0;
       this.cacheHeight = 0;


### PR DESCRIPTION
Turn objectCaching off. This is causing issues on the iPad. With it ON - every object creates a cached canvas when drawing initially, but this is not something that we need. 