### PR TITLE
Weebug 3136 lock canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prepublishOnly": "npm run build"
   },
   "optionalDependencies": {
-    "canvas": "^2.6.1",
+    "canvas": "2.6.1",
     "jsdom": "^15.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When updating from any non-main branch (even pointing to the version main branch is tagged with!) `npm install` will bump the canvas version to 2.8.0, which requires an update to the version of GCC on the machine running anything using it. Jenkins does not have this higher version and will crash as soon as the jest tests start running, triggering a failure. 

If we ever update to a version of fabricjs which needs a newer version of canvas, we can revisit this and determine if updating jenkins is risky/fine/etc. 